### PR TITLE
Minor changes I made

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ usage:
 
 ![screenshots](scr.png)
 
-dependencies: perl >= 5.20, LWP::UserAgent, and possibly Crypt::SSLeay.
+dependencies: perl >= 5.20, LWP::UserAgent, and possibly Mozilla::CA.
 
 Likely you will want to have a font in your terminal that can render Teletext
 mosaic characters. I strongly recommend getting the amazing and free
-[unscii](http://pelulamu.net/unscii/) raster font by Viznut.
+[unscii](http://viznut.fi/unscii/) raster font by Viznut.
 
 The big thing that makes nott different from other existing NOS TT browsers
 (including the official web-based one) is that we parse actual teletext

--- a/nott
+++ b/nott
@@ -60,6 +60,7 @@ use Carp;
 use utf8;
 use open qw( :encoding(UTF-8) :std );
 use LWP::UserAgent;
+use Mozilla::CA;
 #use Data::Dump;
 use FindBin;
 


### PR DESCRIPTION
The provided URL for unscii took me to a domain purchase page so I swapped it for a different one that I found. I tried the unscii-8 font and verified it worked.
I was getting the error `Failed: 500 Can't verify SSL peers without knowing which Certificate Authorities to trust.` with `LWP::UserAgent`. The solution I found was to use `Mozilla::CA`. I looked into `Crypt::SSLeay` and it looks like it is only maintained for legacy code. I also saw a couple of mentions of `Net::SSL` and `IO::Socket::SSL` but both of those seem to not have hostname validation.

Dank,
Jordan